### PR TITLE
FE_78, 86, 87 이슈 해결

### DIFF
--- a/frontend/src/Components/ExpiredInfo.tsx
+++ b/frontend/src/Components/ExpiredInfo.tsx
@@ -23,7 +23,11 @@ const ExpiredInfo = () => {
     if (todayString.isAfter(expire_time)) {
       const overDays = todayString.diff(expire_time, "days");
       return (
-        <ExpiredMessage>연체 상황 : {overDays}일 째 연체 중!</ExpiredMessage>
+        <ExpiredMessage>
+          {overDays === 0
+            ? `금일 대여기간 만료 예정`
+            : `${overDays}일 째 연체 중!`}
+        </ExpiredMessage>
       );
     } else {
       return <div>연체 상황 : 해당 없음</div>;

--- a/frontend/src/Pages/SearchDashboard.tsx
+++ b/frontend/src/Pages/SearchDashboard.tsx
@@ -5,6 +5,7 @@ import PrevUserTable from "../Tables/PrevUserTable";
 import { useSelector, useDispatch, shallowEqual } from "react-redux";
 import { GetTargetResponse } from "../ReduxModules/SearchResponse";
 import { RootState } from "../ReduxModules/rootReducer";
+import { dataInitialize } from "../ReduxModules/SearchResponse";
 import NoPrevLog from "../Components/NoPrevLog";
 import { useSearchParams } from "react-router-dom";
 import * as API from "../Networks/APIType";
@@ -75,6 +76,13 @@ const SearchDashboard = () => {
       return <CabinetDetail />;
     }
   };
+
+  // 페이지 벗어날 때 redux state 초기화 -> 다른 페이지에서 가져다 쓰거나 다시 돌아왔을 때 남아있는 현상 방지
+  useEffect(() => {
+    return () => {
+      dispatch(dataInitialize());
+    };
+  }, [dispatch]);
 
   const TableType = () => {
     if (searchParams.get("intraId") !== null) {

--- a/frontend/src/Tables/BanCabinetTable.tsx
+++ b/frontend/src/Tables/BanCabinetTable.tsx
@@ -50,6 +50,7 @@ export const BanCabinetTable = (props: any) => {
       data,
       initialState: { pageSize: 10 },
       autoResetPage: false,
+      autoResetSortBy: false,
     },
     useSortBy,
     usePagination

--- a/frontend/src/Tables/BanUserTable.tsx
+++ b/frontend/src/Tables/BanUserTable.tsx
@@ -50,6 +50,7 @@ export const BanUserTable = (props: any) => {
       data,
       initialState: { pageSize: 10 },
       autoResetPage: false,
+      autoResetSortBy: false,
     },
     useSortBy,
     usePagination

--- a/frontend/src/Tables/DisabledTable.tsx
+++ b/frontend/src/Tables/DisabledTable.tsx
@@ -50,6 +50,7 @@ export const DisabledTable = (props: any) => {
       data,
       initialState: { pageSize: 10 },
       autoResetPage: false,
+      autoResetSortBy: false,
     },
     useSortBy,
     usePagination

--- a/frontend/src/Tables/ExpiredTable.tsx
+++ b/frontend/src/Tables/ExpiredTable.tsx
@@ -50,6 +50,7 @@ export const ExpiredTable = (props: any) => {
       data,
       initialState: { pageSize: 10 },
       autoResetPage: false,
+      autoResetSortBy: false,
     },
     useSortBy,
     usePagination


### PR DESCRIPTION
1. #78
- 검색 탭에서 넘어갈 때 리덕스 state 초기화
2. #86
- 연체된 날짜가 24시간 미만(0일) 일 때 별도 메시지 출력
3. #87 
- react-table -> useSortBy 옵션 중 autoResetSortBy를 false로 설정