### PR TITLE
Dev #145

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  gateway:
+    container_name: nginx_gateway_admin
+    image: nginx:latest
+    ports:
+      - '81:81'
+    volumes:
+      - ../dev/:/etc/nginx/conf.d/

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 
 services:
-  gateway:
-    container_name: nginx_gateway_admin
+  gateway_admin:
+    container_name: gateway_admin
     image: nginx:latest
     ports:
-      - '81:81'
+      - '81:80'
     volumes:
       - ../dev/:/etc/nginx/conf.d/

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,0 +1,80 @@
+map $http_upgrade $connection_upgrade {
+default upgrade;
+'' close;
+}
+
+map $remote_addr $proxy_forwarded_elem {
+    # IPv4 addresses can be sent as-is
+    ~^[0-9.]+$          "for=$remote_addr";
+
+    # IPv6 addresses need to be bracketed and quoted
+    ~^[0-9A-Fa-f:.]+$   "for=\"[$remote_addr]\"";
+
+    # Unix domain socket names cannot be represented in RFC 7239 syntax
+    default             "for=unknown";
+}
+
+map $http_forwarded $proxy_add_forwarded {
+    # If the incoming Forwarded header is syntactically valid, append to it
+    "~^(,[ \\t]*)*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*([ \\t]*,([ \\t]*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem";
+
+    # Otherwise, replace it
+    default "$proxy_forwarded_elem";
+}
+
+server {
+  listen 81 default_server;
+  server_name  _;
+
+  # Vite
+  location /hmr/ {
+    proxy_pass              http://host.docker.internal:3000/;
+    proxy_http_version                 1.1;
+    proxy_cache_bypass                 $http_upgrade;
+
+    # Proxy headers
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header Forwarded         $proxy_add_forwarded;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Port  $server_port;
+    proxy_set_header Connection        $connection_upgrade;
+
+    # Proxy timeouts
+    proxy_connect_timeout              60s;
+    proxy_send_timeout                 3600s;
+    proxy_read_timeout                 3600s;
+  }
+
+  location / {
+    proxy_pass http://host.docker.internal:3000;
+    proxy_http_version                 1.1;
+    proxy_cache_bypass                 $http_upgrade;
+
+    # Proxy headers
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header Forwarded         $proxy_add_forwarded;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Port  $server_port;
+    proxy_set_header Connection        $connection_upgrade;
+
+    # Proxy timeouts
+    proxy_connect_timeout              60s;
+    proxy_send_timeout                 3600s;
+    proxy_read_timeout                 3600s;
+  }
+
+  location ^~ /api {
+    proxy_pass http://host.docker.internal:8080;
+    proxy_set_header Host $host;
+  }
+}

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -23,7 +23,7 @@ map $http_forwarded $proxy_add_forwarded {
 }
 
 server {
-  listen 81 default_server;
+  listen       80  default_server;
   server_name  _;
 
   # Vite

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
     outDir: "build",
   },
   server: {
+    host: '0.0.0.0',
     port: 3000,
+    strictPort: true,
+    hmr: {
+      port: 3000,
+      clientPort: 3000,
+      host: 'localhost',
+      path: '/hmr/',
+    },
   },
 });


### PR DESCRIPTION
메인 서비스에서처럼 frontend 코드 변경사항이 생길 때마다 빌드하지 않고, 
vite로 watching할 수 있도록, 로컬용 reverse proxy 서버 환경은 구축했습니다.

사용법은 main에서와 같습니다.
0. `git pull origin dev`
1. frontend 디렉토리에서 `npm i`
2. `npm run start` (3000포트에서 프론트 서버 구동)
3. backend 디렉토리에서 `docker-compose up build -d`
4. `npm run start:dev` (8080포트에서 백엔드 서버 구동)
5. 브라우저에서 localhost:81로 접속 (80포트는 메인 서비스에서 사용중입니다.)

당연하지만 메인 서비스와 DB를 공유하기 때문에 main에서 mariadb 컨테이너가 구동중 이어야 합니다..!
