### PR TITLE
:bug: searchByBrokenCabinet 수정

### DIFF
--- a/backend/src/v3/search/repository/search.repository.ts
+++ b/backend/src/v3/search/repository/search.repository.ts
@@ -154,7 +154,7 @@ export class SearchRepository implements ISearchRepository {
   ): Promise<BrokenCabinetInfoPagenationDto> {
     const result = await this.cabinetRepository.findAndCount({
       where: {
-        status: CabinetStatusType.BANNED,
+        status: CabinetStatusType.BROKEN,
       },
       order: { cabinet_id: 'ASC' },
       take: length,


### PR DESCRIPTION
searchByBrokenCabinet 함수에서 BROKEN cabinet이 아닌 BANNED cabinet이 가져와지는 버그 수정 #136